### PR TITLE
구글 로그인 시 유저 확인, 생성 로직 추가

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,6 +6,7 @@ import { ConfigModule } from '@nestjs/config';
 import { UserController } from './user/user.controller';
 import { UserService } from './user/user.service';
 import { UserModule } from './user/user.module';
+import { PrismaModule } from './prisma/prisma.module';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { UserModule } from './user/user.module';
     }),
     AuthModule,
     UserModule,
+    PrismaModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -6,6 +6,7 @@ import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { GoogleStrategy } from './strategy/google.strategy';
 import { JwtStrategy } from './strategy/jwt.stragegy';
+import { PrismaModule } from '../prisma/prisma.module';
 
 @Module({
   imports: [
@@ -14,6 +15,7 @@ import { JwtStrategy } from './strategy/jwt.stragegy';
       secret: jwtConstants.secret,
       signOptions: { expiresIn: '7d' },
     }),
+    PrismaModule,
   ],
   controllers: [AuthController],
   providers: [AuthService, GoogleStrategy, JwtStrategy],

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,8 +1,21 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { User } from '@prisma/client';
+import { UserDto } from '../user/dto/user.dto';
 
 @Injectable()
 export class AuthService {
-  //private readonly logger: Logger = new Logger(this.constructor.name);
+  private readonly logger: Logger = new Logger(AuthService.name);
 
-  constructor() {}
+  constructor(private prisma: PrismaService) {}
+
+  async signUp(data: UserDto): Promise<User> {
+    this.logger.log(`create User : ${data.name}(${data.email})`);
+    return this.prisma.user.create({ data });
+  }
+
+  async getUserByEmail(email: string): Promise<User | null> {
+    this.logger.log(`find by email : ${email})`);
+    return this.prisma.user.findUnique({ where: { email } });
+  }
 }

--- a/src/auth/dto/google.user.ts
+++ b/src/auth/dto/google.user.ts
@@ -1,5 +1,7 @@
 interface GoogleUser {
   email: string;
+  username: string;
+  photo: string;
 }
 
 export type GoogleRequest = Request & { user: GoogleUser };

--- a/src/prisma/prisma.module.ts
+++ b/src/prisma/prisma.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { PrismaService } from './prisma.service';
+
+@Module({
+  providers: [PrismaService],
+  exports: [PrismaService],
+})
+export class PrismaModule {}

--- a/src/prisma/prisma.service.ts
+++ b/src/prisma/prisma.service.ts
@@ -1,0 +1,16 @@
+import { Injectable, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+
+@Injectable()
+export class PrismaService
+  extends PrismaClient
+  implements OnModuleInit, OnModuleDestroy
+{
+  async onModuleInit() {
+    await this.$connect();
+  }
+
+  async onModuleDestroy() {
+    await this.$disconnect();
+  }
+}

--- a/src/user/dto/user.dto.ts
+++ b/src/user/dto/user.dto.ts
@@ -1,0 +1,6 @@
+export interface UserDto {
+  name: string;
+  password: string;
+  email: string;
+  profile_image: string;
+}


### PR DESCRIPTION
prisma를 이용한 create, read 기능 추가
- schema.prisma
```
model User {
  id    Int     @default(autoincrement()) @id
  email String  @unique
  password String
  name String
  profile_image String?
  user_desc String?
}
```
- 위 처럼 구성되어 있을 때, 데이터베이스 관리도구에서 SELECT * FROM "User" 해야 데이터 조회 가능.
- 프리즈마를 이용해 DB접근시에는 아래와 같이 접근.
```ts
async signUp(data: UserDto): Promise<User> {
    this.logger.log(`create User : ${data.name}(${data.email})`);
    return this.prisma.user.create({ data });
  }
```
- model 명의 카멜케이스로 접근가능
    - 예) model: User / this.prisma.user, model: UserAccount / this.prisma.userAccount )